### PR TITLE
refactor: [Customer/Dashboard] 금일 결함 개요 조회 API 리팩토링 (#8)

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -41,16 +41,16 @@ class Image(Base):
 
     annotations = relationship("Annotation", back_populates="image")
 
-# 어노테이션 테이블
+
+# 어노테이션 테이블 (defect_type 제거 → class_id로 대체)
 class Annotation(Base):
     __tablename__ = "Annotations"
 
     annotation_id = Column(Integer, primary_key=True, index=True)
     image_id = Column(Integer, ForeignKey("Images.image_id", ondelete="CASCADE"), nullable=False)
-    defect_type = Column(
-        Enum(DefectTypeEnum, values_callable=lambda obj: [e.value for e in obj], name="defecttypeenum"),
-        nullable=False
-    )
+
+    class_id = Column(Integer, ForeignKey("DefectClasses.class_id", ondelete="RESTRICT"), nullable=False)
+
     date = Column(DateTime, nullable=False)
     conf_score = Column(Float, nullable=True)
     bounding_box = Column(JSON, nullable=False)
@@ -58,8 +58,10 @@ class Annotation(Base):
     status = Column(Enum("pending", "completed", name="statusenum"), nullable=False)
 
     image = relationship("Image", back_populates="annotations")
+    defect_class = relationship("DefectClasses", back_populates="annotations")
 
 
+# 결함 클래스 테이블
 class DefectClasses(Base):
     __tablename__ = "DefectClasses"
 
@@ -68,6 +70,8 @@ class DefectClasses(Base):
     class_color = Column(String(7), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    annotations = relationship("Annotation", back_populates="defect_class")
 
 
 

--- a/domain/annotation/annotation_crud.py
+++ b/domain/annotation/annotation_crud.py
@@ -1,45 +1,54 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import func, cast, Date
 from datetime import datetime, timedelta
-from database.models import Annotation
+from database.models import Annotation, DefectClasses
 
 
 def get_defect_summary(db: Session):
     today = datetime.today().date()
     yesterday = today - timedelta(days=1)
 
-    # 오늘 결함 수 by type
+    # 오늘 결함 수 by class
     today_data = (
-        db.query(Annotation.defect_type, func.count().label("count"))
+        db.query(
+            DefectClasses.class_name,
+            DefectClasses.class_color,
+            func.count().label("count")
+        )
+        .join(Annotation, Annotation.class_id == DefectClasses.class_id)
         .filter(cast(Annotation.date, Date) == today)
-        .group_by(Annotation.defect_type)
+        .group_by(DefectClasses.class_id)
         .all()
     )
 
-    # 어제 결함 수 by type
+    # 어제 결함 수 by class
     yesterday_data = (
-        db.query(Annotation.defect_type, func.count().label("count"))
+        db.query(
+            DefectClasses.class_name,
+            func.count().label("count")
+        )
+        .join(Annotation, Annotation.class_id == DefectClasses.class_id)
         .filter(cast(Annotation.date, Date) == yesterday)
-        .group_by(Annotation.defect_type)
+        .group_by(DefectClasses.class_id)
         .all()
     )
 
     # 딕셔너리 변환
-    today_dict = {row.defect_type.value: row.count for row in today_data}
-    yesterday_dict = {row.defect_type.value: row.count for row in yesterday_data}
+    today_dict = {row.class_name: {"count": row.count, "color": row.class_color} for row in today_data}
+    yesterday_dict = {row.class_name: row.count for row in yesterday_data}
 
-    # 전체 결함 수 및 변화량 정리
-    total_defects = sum(today_dict.values())
-    most_frequent = max(today_dict.items(), key=lambda x: x[1])[0] if today_dict else None
+    total_defects = sum([info["count"] for info in today_dict.values()])
+    most_frequent = max(today_dict.items(), key=lambda x: x[1]["count"])[0] if today_dict else None
 
     by_type = {}
-    for defect_type in set(today_dict.keys()).union(yesterday_dict.keys()):
-        today_count = today_dict.get(defect_type, 0)
-        yest_count = yesterday_dict.get(defect_type, 0)
+    for class_name in set(today_dict.keys()).union(yesterday_dict.keys()):
+        today_info = today_dict.get(class_name, {"count": 0, "color": "#ffffff"})
+        yesterday_count = yesterday_dict.get(class_name, 0)
 
-        by_type[defect_type] = {
-            "count": today_count,
-            "change": today_count - yest_count
+        by_type[class_name] = {
+            "count": today_info["count"],
+            "color": today_info["color"],
+            "change": today_info["count"] - yesterday_count
         }
 
     return {

--- a/domain/annotation/annotation_schema.py
+++ b/domain/annotation/annotation_schema.py
@@ -2,10 +2,16 @@ from pydantic import BaseModel
 from typing import Dict
 
 
+class DefectCountInfo(BaseModel):
+    count: int
+    color: str  # HEX 색상 (예: "#dbe4ff")
+    change: int  # 전일 대비 증감 수치
+
+
 class DefectSummaryResponse(BaseModel):
     total_defect_count: int
-    most_frequent_defect: str
-    defect_counts_by_type: Dict[str, Dict[str, int]]
+    most_frequent_defect: str  # class_name
+    defect_counts_by_type: Dict[str, DefectCountInfo]  # class_name -> {count, color}
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
- [Customer/Edit class] 결함 클래스 목록 조회 API 개발 도중 변경된 ERD를 반영하여 [Customer/Dashboard] 금일 결함 개요 조회 API 리팩토링. 
- 응답 정보에 bounding box color도 추가 
<img width="1505" alt="image" src="https://github.com/user-attachments/assets/06acfba3-e8ed-4c8b-aa23-6e0985ae459c" />

Closes #8 


